### PR TITLE
rotate arrow on mobile menu on click

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -330,6 +330,9 @@ h2 {
 .hamburger:hover {
   cursor: pointer;
 }
+.rotate_arrow {
+  transform: rotate(180deg);
+}
 .text {
   font-weight: 300;
   line-height: 1.5em;


### PR DESCRIPTION
I was finally able to rotate the arrow icon on mobile menu by simply manipulating the DOM with JS.

Location:
Js/js.js
LESS/index.less
styles/index.css

```js
function changeIcon(id) {
    var icon = document.querySelector(".dropdown_title_mobile#" + id + " > #change");
    icon.classList.toggle("rotate_arrow");


}

```